### PR TITLE
PYMT-569: Update the exception handler to accept translator keys

### DIFF
--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -29,7 +29,7 @@ class AnnotationReader extends BaseAnnotationReader implements AnnotationReaderI
             parent::__construct();
         } catch (AnnotationException $exception) {
             // Convert to AnnotationCacheException
-            throw new AnnotationCacheException($exception->getMessage(), $exception->getCode(), $exception);
+            throw new AnnotationCacheException($exception->getMessage(), null, $exception->getCode(), $exception);
         }
     }
 

--- a/src/DateInterval.php
+++ b/src/DateInterval.php
@@ -22,7 +22,7 @@ class DateInterval extends BaseDateInterval
             // Create parent object
             parent::__construct($interval);
         } catch (Exception $exception) {
-            throw new InvalidDateTimeIntervalException('The date/time interval is invalid', null, $exception);
+            throw new InvalidDateTimeIntervalException('The date/time interval is invalid', null, null, $exception);
         }
     }
 

--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -24,7 +24,7 @@ class DateTime extends BaseDateTime
             // Create parent object
             parent::__construct($timestamp ?? 'now', $timezone);
         } catch (Exception $exception) {
-            throw new InvalidDateTimeStringException('The date/time provided is invalid', null, $exception);
+            throw new InvalidDateTimeStringException('The date/time provided is invalid', null, null, $exception);
         }
     }
 

--- a/src/Exceptions/BaseException.php
+++ b/src/Exceptions/BaseException.php
@@ -10,14 +10,33 @@ use Throwable;
 abstract class BaseException extends Exception implements BaseExceptionInterface
 {
     /**
+     * @var mixed[]
+     */
+    protected $messageParams;
+
+    /**
      * BaseException constructor.
      *
      * @param null|string $message
      * @param int|null $code
      * @param \Throwable|null $previous
+     * @param mixed[]|null $messageParameters Parameters for $message
      */
-    public function __construct(?string $message = null, ?int $code = null, ?Throwable $previous = null)
-    {
+    public function __construct(
+        ?string $message = null,
+        ?int $code = null,
+        ?Throwable $previous = null,
+        ?array $messageParameters = null
+    ) {
         parent::__construct($message ?? '', $code ?? 0, $previous);
+        $this->messageParams = $messageParameters ?? [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMessageParameters(): array
+    {
+        return $this->messageParams;
     }
 }

--- a/src/Exceptions/BaseException.php
+++ b/src/Exceptions/BaseException.php
@@ -18,15 +18,15 @@ abstract class BaseException extends Exception implements BaseExceptionInterface
      * BaseException constructor.
      *
      * @param null|string $message
+     * @param mixed[]|null $messageParameters Parameters for $message
      * @param int|null $code
      * @param \Throwable|null $previous
-     * @param mixed[]|null $messageParameters Parameters for $message
      */
     public function __construct(
         ?string $message = null,
+        ?array $messageParameters = null,
         ?int $code = null,
-        ?Throwable $previous = null,
-        ?array $messageParameters = null
+        ?Throwable $previous = null
     ) {
         parent::__construct($message ?? '', $code ?? 0, $previous);
         $this->messageParams = $messageParameters ?? [];

--- a/src/Exceptions/UnexpectedTypeException.php
+++ b/src/Exceptions/UnexpectedTypeException.php
@@ -21,7 +21,7 @@ class UnexpectedTypeException extends RuntimeException
             $expectedType
         );
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, null, $code, $previous);
     }
 
     /**

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -32,7 +32,7 @@ abstract class ValidationException extends BaseException implements ValidationEx
         ?Throwable $previous = null,
         ?array $errors = null
     ) {
-        parent::__construct($message ?? '', $code ?? 0, $previous);
+        parent::__construct($message ?? '', null, $code ?? 0, $previous);
 
         $this->errors = $errors ?? [];
     }

--- a/src/Interfaces/Exceptions/ExceptionInterface.php
+++ b/src/Interfaces/Exceptions/ExceptionInterface.php
@@ -22,6 +22,13 @@ interface ExceptionInterface extends Throwable
     public function getErrorSubCode(): int;
 
     /**
+     * Get message parameters
+     *
+     * @return mixed[]
+     */
+    public function getMessageParameters(): array;
+
+    /**
      * Get Error Response status code.
      *
      * @return int

--- a/src/UtcDateTime.php
+++ b/src/UtcDateTime.php
@@ -34,7 +34,7 @@ class UtcDateTime implements UtcDateTimeInterface
             $this->datetime = (new DateTime($datetime->format('Y-m-d H:i:s'), new DateTimeZone('UTC')))
                 ->setTimezone(new DateTimeZone('UTC'));
         } catch (Exception $exception) {
-            throw new InvalidDateTimeStringException('The date/time provided is invalid', null, $exception);
+            throw new InvalidDateTimeStringException('The date/time provided is invalid', null, null, $exception);
         }
     }
 

--- a/tests/Exceptions/ValidationExceptionTest.php
+++ b/tests/Exceptions/ValidationExceptionTest.php
@@ -22,6 +22,19 @@ class ValidationExceptionTest extends TestCase
     }
 
     /**
+     * A test to get coverage
+     *
+     * TODO: Once PYMT-569 has been decided upon, move this to a more logical place
+     *
+     * @return void
+     */
+    public function testGetMessageParameters(): void
+    {
+        $exception = new ValidationExceptionStub(null, null, null, []);
+        self::assertIsArray($exception->getMessageParameters());
+    }
+
+    /**
      * Exception should return valid codes.
      *
      * @return void

--- a/tests/Exceptions/ValidationExceptionTest.php
+++ b/tests/Exceptions/ValidationExceptionTest.php
@@ -6,6 +6,10 @@ namespace Tests\EoneoPay\Utils\Exceptions;
 use Tests\EoneoPay\Utils\Stubs\Exceptions\ValidationExceptionStub;
 use Tests\EoneoPay\Utils\TestCase;
 
+/**
+ * @covers \EoneoPay\Utils\Exceptions\BaseException
+ * @covers \EoneoPay\Utils\Exceptions\ValidationException
+ */
 class ValidationExceptionTest extends TestCase
 {
     /**
@@ -23,8 +27,6 @@ class ValidationExceptionTest extends TestCase
 
     /**
      * A test to get coverage
-     *
-     * TODO: Once PYMT-569 has been decided upon, move this to a more logical place
      *
      * @return void
      */


### PR DESCRIPTION
Updates to ExceptionInterface to enable Exceptions to pass message string format parameters to the exception handler.

[Link to card](https://loyaltycorp.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PYMT&modal=detail&selectedIssue=PYMT-569&assignee=rashmit)

The core idea here is to be able to get rid of Translator from exception constructors. So just a translatable key could be passed as an argument and ExceptionHandler does the translation in itself.