### PR TITLE
PYMT-1044 Remove catching container exception.

### DIFF
--- a/src/Bridge/Lumen/Resolvers/ControllerResolver.php
+++ b/src/Bridge/Lumen/Resolvers/ControllerResolver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace EoneoPay\Utils\Bridge\Lumen\Resolvers;
 
 use EoneoPay\Utils\Bridge\Lumen\Interfaces\Resolvers\ControllerResolverInterface;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Routing\Route;
 
@@ -30,6 +29,8 @@ final class ControllerResolver implements ControllerResolverInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function resolve($route): ?callable
     {
@@ -40,12 +41,7 @@ final class ControllerResolver implements ControllerResolverInterface
             return null;
         }
 
-        try {
-            $controller = $this->container->make($split[0]);
-        } /** @noinspection BadExceptionsProcessingInspection */ catch (BindingResolutionException $exception) {
-            return null;
-        }
-
+        $controller = $this->container->make($split[0]);
         $callable = [$controller, $split[1]];
 
         if (\is_callable($callable) === false) {

--- a/tests/Bridge/Lumen/Resolvers/ControllerResolverTest.php
+++ b/tests/Bridge/Lumen/Resolvers/ControllerResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\EoneoPay\Utils\Bridge\Lumen\Resolvers;
 
 use EoneoPay\Utils\Bridge\Lumen\Resolvers\ControllerResolver;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Routing\Route;
 use stdClass;
 use Tests\EoneoPay\Utils\Stubs\Vendor\Laravel\ContainerStub;
@@ -15,6 +16,8 @@ class ControllerResolverTest extends TestCase
      * Tests a route that references a controller not bound in the container.
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testBadlyConfiguredContainer(): void
     {
@@ -32,6 +35,8 @@ class ControllerResolverTest extends TestCase
      * Tests a laravel route that does not have a uses section.
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testMisconfiguredLaravelRoute(): void
     {
@@ -46,6 +51,8 @@ class ControllerResolverTest extends TestCase
      * Tests a laravel route with no method to call
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testMisconfiguredLaravelRouteNoMethod(): void
     {
@@ -60,6 +67,8 @@ class ControllerResolverTest extends TestCase
      * Tests a lumen route that does not have a uses section.
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testMisconfiguredLumenRoute(): void
     {
@@ -74,20 +83,25 @@ class ControllerResolverTest extends TestCase
      * Tests a route that references a controller not bound in the container.
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testMissingController(): void
     {
         $resolver = new ControllerResolver(new ContainerStub());
 
-        $result = $resolver->resolve(new Route('POST', '', ['uses' => 'NopeController@nope']));
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionCode(0);
 
-        static::assertNull($result);
+        $resolver->resolve(new Route('POST', '', ['uses' => 'NopeController@nope']));
     }
 
     /**
      * Tests that the controller resolver returns null when an unknown route is provided
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testResolveUnknownRoute(): void
     {
@@ -102,6 +116,8 @@ class ControllerResolverTest extends TestCase
      * Tests resolution
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function testSuccess(): void
     {


### PR DESCRIPTION
The `ControllerResolver` swallows any exceptions thrown by the container while it tries to resolve the controller. This means that if there is a problem creating a controller (eg, missing services), the exception/errors that we get do not indicate this as the problem.

**Fix:**

The resolver does not catch exception while resolving controller and let it throw by container for the consuming application to handle accordingly.

Ticket: [https://loyaltycorp.atlassian.net/browse/PYMT-1044](https://loyaltycorp.atlassian.net/browse/PYMT-1044)